### PR TITLE
PHPUnit improvements

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,7 +10,7 @@
     </testsuites>
 
     <filter>
-        <whitelist>
+        <whitelist processUncoveredFilesFromWhitelist="true">
             <directory suffix=".php">./src</directory>
         </whitelist>
     </filter>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,7 +4,7 @@
          bootstrap="vendor/autoload.php"
          colors="true">
     <testsuites>
-        <testsuite name="zend-expressive-cache">
+        <testsuite name="zend-expressive-authorization">
             <directory>./test</directory>
         </testsuite>
     </testsuites>

--- a/test/AuthorizationMiddlewareFactoryTest.php
+++ b/test/AuthorizationMiddlewareFactoryTest.php
@@ -13,6 +13,7 @@ use Psr\Http\Message\ResponseInterface;
 use Zend\Expressive\Authorization\AuthorizationInterface;
 use Zend\Expressive\Authorization\AuthorizationMiddleware;
 use Zend\Expressive\Authorization\AuthorizationMiddlewareFactory;
+use Zend\Expressive\Authorization\Exception;
 
 class AuthorizationMiddlewareFactoryTest extends TestCase
 {
@@ -31,24 +32,20 @@ class AuthorizationMiddlewareFactoryTest extends TestCase
             ->will([$this->response, 'reveal']);
     }
 
-    /**
-     * @expectedException Zend\Expressive\Authorization\Exception\InvalidConfigException
-     */
     public function testFactoryWithoutAuthorization()
     {
         $this->container->has(AuthorizationInterface::class)->willReturn(false);
 
+        $this->expectException(Exception\InvalidConfigException::class);
         $middleware = ($this->factory)($this->container->reveal());
     }
 
-    /**
-     * @expectedException Zend\Expressive\Authorization\Exception\InvalidConfigException
-     */
     public function testFactoryWithoutResponsePrototype()
     {
         $this->container->has(AuthorizationInterface::class)->willReturn(true);
         $this->container->has(ResponseInterface::class)->willReturn(false);
 
+        $this->expectException(Exception\InvalidConfigException::class);
         $middleware = ($this->factory)($this->container->reveal());
     }
 


### PR DESCRIPTION
Changed to `expectException` method calls instead of PHPUnit annotations.
It is more accurate, because we can put it just before call which should throw an exception.

Fixed also testsuite name in `phpunit.xml.dist`.