### PR TITLE
PHPDocs fixes

### DIFF
--- a/src/AuthorizationInterface.php
+++ b/src/AuthorizationInterface.php
@@ -14,5 +14,5 @@ interface AuthorizationInterface
     /**
      * Check if a role is granted for the request
      */
-    public function isGranted(string $role, ServerRequestInterface $request): bool;
+    public function isGranted(string $role, ServerRequestInterface $request) : bool;
 }

--- a/src/AuthorizationInterface.php
+++ b/src/AuthorizationInterface.php
@@ -13,10 +13,6 @@ interface AuthorizationInterface
 {
     /**
      * Check if a role is granted for the request
-     *
-     * @param string $role
-     * @param ServerRequestInterface $request
-     * @return bool
      */
     public function isGranted(string $role, ServerRequestInterface $request): bool;
 }

--- a/src/AuthorizationMiddleware.php
+++ b/src/AuthorizationMiddleware.php
@@ -24,13 +24,6 @@ class AuthorizationMiddleware implements ServerMiddlewareInterface
      */
     private $responsePrototype;
 
-    /**
-     * Constructor
-     *
-     * @param Rbac $rbac
-     * @param MiddlewareAssertionInterface $assertion
-     * @return void
-     */
     public function __construct(AuthorizationInterface $authorization, ResponseInterface $responsePrototype)
     {
         $this->authorization = $authorization;

--- a/src/AuthorizationMiddlewareFactory.php
+++ b/src/AuthorizationMiddlewareFactory.php
@@ -10,7 +10,6 @@ namespace Zend\Expressive\Authorization;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
 use Zend\Diactoros\Response;
-use Zend\Expressive\Authorization\AuthorizationInterface;
 
 class AuthorizationMiddlewareFactory
 {

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -7,8 +7,6 @@
 
 namespace Zend\Expressive\Authorization;
 
-use Zend\Permission\Rbac\Rbac;
-
 class ConfigProvider
 {
     /**


### PR DESCRIPTION
- removed redundant tags in PHPDocs
- removed invalid PHPDocs
- removed unused imports.
- added space before colon in return type declaration (consistency fix)
