### PR TITLE
Added support for http-interop/http-middleware 0.5.0 (no BC Break)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,8 @@
     },
     "repositories": [
         {
-            "type": "vcs",
-            "url": "git://github.com/webimpress/zend-expressive-router.git"
+            "type": "git",
+            "url": "https://github.com/webimpress/zend-expressive-router.git"
         }
     ],
     "require": {

--- a/composer.json
+++ b/composer.json
@@ -20,18 +20,12 @@
         "slack": "https://zendframework-slack.herokuapp.com",
         "forum": "https://discourse.zendframework.com/c/questions/expressive"
     },
-    "repositories": [
-        {
-            "type": "git",
-            "url": "https://github.com/webimpress/zend-expressive-router.git"
-        }
-    ],
     "require": {
         "php": "^7.1",
         "psr/container": "^1.0",
         "psr/http-message": "^1.0.1",
         "webimpress/http-middleware-compatibility": "^0.1.1",
-        "zendframework/zend-expressive-router": "dev-feature/http-middleware-0.5"
+        "zendframework/zend-expressive-router": "^2.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.0.8",

--- a/composer.json
+++ b/composer.json
@@ -20,12 +20,18 @@
         "slack": "https://zendframework-slack.herokuapp.com",
         "forum": "https://discourse.zendframework.com/c/questions/expressive"
     },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "git://github.com/webimpress/zend-expressive-router.git"
+        }
+    ],
     "require": {
-        "http-interop/http-middleware": "^0.4.1",
         "php": "^7.1",
         "psr/container": "^1.0",
         "psr/http-message": "^1.0.1",
-        "zendframework/zend-expressive-router": "^2.1.0"
+        "webimpress/http-middleware-compatibility": "^0.1.1",
+        "zendframework/zend-expressive-router": "dev-feature/http-middleware-0.5"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.0.8",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "313eccc05ecdbce31914c400bc9a2f54",
+    "content-hash": "d29d73c36314b16a87292e3366fa8822",
     "packages": [
         {
             "name": "fig/http-message-util",
@@ -249,16 +249,16 @@
         },
         {
             "name": "zendframework/zend-expressive-router",
-            "version": "dev-feature/http-middleware-0.5",
+            "version": "2.2.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/webimpress/zend-expressive-router.git",
-                "reference": "6d385d9f2f29194f8b5c9073a3d09e46affd86d7"
+                "url": "https://github.com/zendframework/zend-expressive-router.git",
+                "reference": "f6eac53d39cdbf7b6db11b3e6bb3565896633de4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webimpress/zend-expressive-router/zipball/6d385d9f2f29194f8b5c9073a3d09e46affd86d7",
-                "reference": "6d385d9f2f29194f8b5c9073a3d09e46affd86d7",
+                "url": "https://api.github.com/repos/zendframework/zend-expressive-router/zipball/f6eac53d39cdbf7b6db11b3e6bb3565896633de4",
+                "reference": "f6eac53d39cdbf7b6db11b3e6bb3565896633de4",
                 "shasum": ""
             },
             "require": {
@@ -280,8 +280,8 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.1-dev",
-                    "dev-develop": "2.2-dev"
+                    "dev-master": "2.2-dev",
+                    "dev-develop": "2.3-dev"
                 }
             },
             "autoload": {
@@ -289,36 +289,7 @@
                     "Zend\\Expressive\\Router\\": "src/"
                 }
             },
-            "autoload-dev": {
-                "psr-4": {
-                    "ZendTest\\Expressive\\Router\\": "test/"
-                }
-            },
-            "scripts": {
-                "check": [
-                    "@license-check",
-                    "@cs-check",
-                    "@test"
-                ],
-                "upload-coverage": [
-                    "coveralls -v"
-                ],
-                "cs-check": [
-                    "phpcs --colors"
-                ],
-                "cs-fix": [
-                    "phpcbf --colors"
-                ],
-                "license-check": [
-                    "docheader check src/ test/"
-                ],
-                "test": [
-                    "phpunit --colors=always"
-                ],
-                "test-coverage": [
-                    "phpunit --coverage-clover clover.xml"
-                ]
-            },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "BSD-3-Clause"
             ],
@@ -330,10 +301,7 @@
                 "psr",
                 "psr-7"
             ],
-            "support": {
-                "source": "https://github.com/webimpress/zend-expressive-router/tree/feature/http-middleware-0.5"
-            },
-            "time": "2017-10-05T16:20:19+00:00"
+            "time": "2017-10-09T18:44:11+00:00"
         }
     ],
     "packages-dev": [
@@ -2035,7 +2003,6 @@
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
-        "zendframework/zend-expressive-router": 20,
         "roave/security-advisories": 20
     },
     "prefer-stable": false,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "4c83be6826071e25f8f848809c816f9d",
+    "content-hash": "313eccc05ecdbce31914c400bc9a2f54",
     "packages": [
         {
             "name": "fig/http-message-util",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "7fc1fb70480aa2098f7cc05f7d303699",
+    "content-hash": "4c83be6826071e25f8f848809c816f9d",
     "packages": [
         {
             "name": "fig/http-message-util",
@@ -58,16 +58,16 @@
         },
         {
             "name": "http-interop/http-middleware",
-            "version": "0.4.1",
+            "version": "0.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/http-interop/http-middleware.git",
-                "reference": "9a801fe60e70d5d608b61d56b2dcde29516c81b9"
+                "reference": "b49e1f9f6c584e704317b563302e566b8ce11858"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/http-interop/http-middleware/zipball/9a801fe60e70d5d608b61d56b2dcde29516c81b9",
-                "reference": "9a801fe60e70d5d608b61d56b2dcde29516c81b9",
+                "url": "https://api.github.com/repos/http-interop/http-middleware/zipball/b49e1f9f6c584e704317b563302e566b8ce11858",
+                "reference": "b49e1f9f6c584e704317b563302e566b8ce11858",
                 "shasum": ""
             },
             "require": {
@@ -82,7 +82,7 @@
             },
             "autoload": {
                 "psr-4": {
-                    "Interop\\Http\\ServerMiddleware\\": "src/"
+                    "Interop\\Http\\Server\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -97,16 +97,15 @@
             ],
             "description": "Common interface for HTTP server-side middleware",
             "keywords": [
-                "factory",
                 "http",
                 "middleware",
                 "psr",
-                "psr-17",
+                "psr-15",
                 "psr-7",
                 "request",
                 "response"
             ],
-            "time": "2017-01-14T15:23:42+00:00"
+            "time": "2017-09-18T15:27:03+00:00"
         },
         {
             "name": "psr/container",
@@ -208,28 +207,68 @@
             "time": "2016-08-06T14:39:51+00:00"
         },
         {
-            "name": "zendframework/zend-expressive-router",
-            "version": "2.1.0",
+            "name": "webimpress/http-middleware-compatibility",
+            "version": "0.1.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/zendframework/zend-expressive-router.git",
-                "reference": "88d711aee740ac8fbd684472469e16b85435cc79"
+                "url": "https://github.com/webimpress/http-middleware-compatibility.git",
+                "reference": "793d21864a0417bbe01437c33f902cac49c1788c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-expressive-router/zipball/88d711aee740ac8fbd684472469e16b85435cc79",
-                "reference": "88d711aee740ac8fbd684472469e16b85435cc79",
+                "url": "https://api.github.com/repos/webimpress/http-middleware-compatibility/zipball/793d21864a0417bbe01437c33f902cac49c1788c",
+                "reference": "793d21864a0417bbe01437c33f902cac49c1788c",
                 "shasum": ""
             },
             "require": {
-                "fig/http-message-util": "^1.1",
-                "http-interop/http-middleware": "^0.4.1",
+                "http-interop/http-middleware": "^0.1.1 || ^0.2 || ^0.3 || ^0.4.1 || ^0.5",
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7.22 || ^6.3.1"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "autoload/http-middleware.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "description": "Compatibility library for Draft PSR-15 HTTP Middleware",
+            "homepage": "https://github.com/webimpress/http-middleware-compatibility",
+            "keywords": [
+                "middleware",
+                "psr-15",
+                "webimpress"
+            ],
+            "time": "2017-10-05T15:55:30+00:00"
+        },
+        {
+            "name": "zendframework/zend-expressive-router",
+            "version": "dev-feature/http-middleware-0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webimpress/zend-expressive-router.git",
+                "reference": "6d385d9f2f29194f8b5c9073a3d09e46affd86d7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webimpress/zend-expressive-router/zipball/6d385d9f2f29194f8b5c9073a3d09e46affd86d7",
+                "reference": "6d385d9f2f29194f8b5c9073a3d09e46affd86d7",
+                "shasum": ""
+            },
+            "require": {
+                "fig/http-message-util": "^1.1.2",
                 "php": "^5.6 || ^7.0",
-                "psr/http-message": "^1.0"
+                "psr/http-message": "^1.0.1",
+                "webimpress/http-middleware-compatibility": "^0.1.1"
             },
             "require-dev": {
                 "malukenho/docheader": "^0.1.5",
-                "phpunit/phpunit": "^4.7 || ^5.6",
+                "phpunit/phpunit": "^6.0.8 || ^5.7.15",
                 "zendframework/zend-coding-standard": "~1.0.0"
             },
             "suggest": {
@@ -249,7 +288,36 @@
                     "Zend\\Expressive\\Router\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "ZendTest\\Expressive\\Router\\": "test/"
+                }
+            },
+            "scripts": {
+                "check": [
+                    "@license-check",
+                    "@cs-check",
+                    "@test"
+                ],
+                "upload-coverage": [
+                    "coveralls -v"
+                ],
+                "cs-check": [
+                    "phpcs --colors"
+                ],
+                "cs-fix": [
+                    "phpcbf --colors"
+                ],
+                "license-check": [
+                    "docheader check src/ test/"
+                ],
+                "test": [
+                    "phpunit --colors=always"
+                ],
+                "test-coverage": [
+                    "phpunit --coverage-clover clover.xml"
+                ]
+            },
             "license": [
                 "BSD-3-Clause"
             ],
@@ -261,7 +329,10 @@
                 "psr",
                 "psr-7"
             ],
-            "time": "2017-01-24T22:28:12+00:00"
+            "support": {
+                "source": "https://github.com/webimpress/zend-expressive-router/tree/feature/http-middleware-0.5"
+            },
+            "time": "2017-10-05T16:20:19+00:00"
         }
     ],
     "packages-dev": [
@@ -1963,6 +2034,7 @@
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
+        "zendframework/zend-expressive-router": 20,
         "roave/security-advisories": 20
     },
     "prefer-stable": false,

--- a/composer.lock
+++ b/composer.lock
@@ -58,16 +58,16 @@
         },
         {
             "name": "http-interop/http-middleware",
-            "version": "0.5.0",
+            "version": "0.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/http-interop/http-middleware.git",
-                "reference": "b49e1f9f6c584e704317b563302e566b8ce11858"
+                "reference": "9a801fe60e70d5d608b61d56b2dcde29516c81b9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/http-interop/http-middleware/zipball/b49e1f9f6c584e704317b563302e566b8ce11858",
-                "reference": "b49e1f9f6c584e704317b563302e566b8ce11858",
+                "url": "https://api.github.com/repos/http-interop/http-middleware/zipball/9a801fe60e70d5d608b61d56b2dcde29516c81b9",
+                "reference": "9a801fe60e70d5d608b61d56b2dcde29516c81b9",
                 "shasum": ""
             },
             "require": {
@@ -82,7 +82,7 @@
             },
             "autoload": {
                 "psr-4": {
-                    "Interop\\Http\\Server\\": "src/"
+                    "Interop\\Http\\ServerMiddleware\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -97,15 +97,16 @@
             ],
             "description": "Common interface for HTTP server-side middleware",
             "keywords": [
+                "factory",
                 "http",
                 "middleware",
                 "psr",
-                "psr-15",
+                "psr-17",
                 "psr-7",
                 "request",
                 "response"
             ],
-            "time": "2017-09-18T15:27:03+00:00"
+            "time": "2017-01-14T15:23:42+00:00"
         },
         {
             "name": "psr/container",

--- a/src/AuthorizationMiddleware.php
+++ b/src/AuthorizationMiddleware.php
@@ -7,12 +7,14 @@
 
 namespace Zend\Expressive\Authorization;
 
-use Interop\Http\ServerMiddleware\DelegateInterface;
-use Interop\Http\ServerMiddleware\MiddlewareInterface as ServerMiddlewareInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface;
+use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface;
 
-class AuthorizationMiddleware implements ServerMiddlewareInterface
+use const Webimpress\HttpMiddlewareCompatibility\HANDLER_METHOD;
+
+class AuthorizationMiddleware implements MiddlewareInterface
 {
     /**
      * @var AuthorizationInterface
@@ -34,7 +36,7 @@ class AuthorizationMiddleware implements ServerMiddlewareInterface
      * {@inheritDoc}
      * @todo Use role/identity interface from zend-expressive-authentication once published.
      */
-    public function process(ServerRequestInterface $request, DelegateInterface $delegate)
+    public function process(ServerRequestInterface $request, HandlerInterface $handler)
     {
         $role = $request->getAttribute(AuthorizationInterface::class, false);
 
@@ -43,7 +45,7 @@ class AuthorizationMiddleware implements ServerMiddlewareInterface
         }
 
         return $this->authorization->isGranted($role, $request)
-            ? $delegate->process($request)
+            ? $handler->{HANDLER_METHOD}($request)
             : $this->responsePrototype->withStatus(403);
     }
 }

--- a/test/AuthorizationMiddlewareTest.php
+++ b/test/AuthorizationMiddlewareTest.php
@@ -7,14 +7,15 @@
 
 namespace ZendTest\Expressive\Authorization;
 
-use Interop\Http\ServerMiddleware\DelegateInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface;
 use Zend\Expressive\Authorization\AuthorizationInterface;
 use Zend\Expressive\Authorization\AuthorizationMiddleware;
-use Zend\Expressive\Router\RouteResult;
+
+use const Webimpress\HttpMiddlewareCompatibility\HANDLER_METHOD;
 
 class AuthorizationMiddlewareTest extends TestCase
 {
@@ -22,7 +23,7 @@ class AuthorizationMiddlewareTest extends TestCase
     {
         $this->authorization = $this->prophesize(AuthorizationInterface::class);
         $this->request = $this->prophesize(ServerRequestInterface::class);
-        $this->delegate = $this->prophesize(DelegateInterface::class);
+        $this->delegate = $this->prophesize(HandlerInterface::class);
         $this->response = $this->prophesize(ResponseInterface::class);
     }
 
@@ -69,7 +70,7 @@ class AuthorizationMiddlewareTest extends TestCase
         $this->authorization->isGranted('foo', $this->request->reveal())->willReturn(true);
 
         $middleware = new AuthorizationMiddleware($this->authorization->reveal(), $this->response->reveal());
-        $this->delegate->process(Argument::any())->willReturn($this->response->reveal());
+        $this->delegate->{HANDLER_METHOD}(Argument::any())->willReturn($this->response->reveal());
 
         $response = $middleware->process(
             $this->request->reveal(),


### PR DESCRIPTION
We keep also support for previous versions. Now consumer of the library can choose version of http-middleware to use, and it allows to update to the lates version at any time.
We are using `webimpress/http-middleware-compatibility` library to make it possible.

**Requires https://github.com/zendframework/zend-expressive-router/pull/36 to be merged and released first, then we need update `composer.json` in that PR to point new released version of `zend-expressive-router`.**